### PR TITLE
Update stack resolver (needed for build since 30df524e7b)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.7
+resolver: lts-19.1
 extra-deps: []
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
Without this change `stack test` fails:

```
% stack test

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for aeson-diff-1.1.0.12:
    aeson-1.4.5.0 from stack configuration does not match >=2.0.3  (latest matching version is 2.0.3.0)
needed since aeson-diff is a build target.
...
```