### PR TITLE
Add YAML support

### DIFF
--- a/aeson-diff.cabal
+++ b/aeson-diff.cabal
@@ -46,21 +46,25 @@ executable             json-diff
   default-language:    Haskell2010
   hs-source-dirs:      src
   main-is:             diff.hs
+  other-modules:       Codec
   build-depends:       base
                      , aeson >= 2.0.3
                      , aeson-diff
                      , bytestring
                      , optparse-applicative
+                     , yaml
 
 executable             json-patch
   default-language:    Haskell2010
   hs-source-dirs:      src
   main-is:             patch.hs
+  other-modules:       Codec
   build-depends:       base
                      , aeson >= 2.0.3
                      , aeson-diff
                      , bytestring
                      , optparse-applicative
+                     , yaml
 
 test-suite             properties
   default-language:    Haskell2010

--- a/src/Codec.hs
+++ b/src/Codec.hs
@@ -1,0 +1,34 @@
+module Codec (encode, decode, AesonFormat (..)) where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Yaml as Yaml
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
+import           Control.Applicative ((<|>))
+import           Data.Char           (toLower)
+import           Data.List           (isSuffixOf)
+
+data AesonFormat = AesonJSON | AesonYAML deriving (Show, Eq)
+
+decode :: Aeson.FromJSON a => Maybe AesonFormat -> Maybe FilePath -> BL.ByteString -> Maybe a
+decode (Just AesonYAML) _ = decodeYamlFirst
+decode (Just AesonJSON) _ = decodeJsonFirst
+decode _ (Just fn) | ".yaml" `isSuffixOf` (toLower <$> fn) ||
+                     ".yml"  `isSuffixOf` (toLower <$> fn) = decodeYamlFirst
+decode _ (Just fn) | ".json" `isSuffixOf` (toLower <$> fn) = decodeJsonFirst
+decode _ _ = decodeJsonFirst
+
+
+decodeYamlFirst :: Aeson.FromJSON a => BL.ByteString -> Maybe a
+decodeYamlFirst s = Yaml.decodeThrow (BL.toStrict s) <|> Aeson.decode s
+
+decodeJsonFirst :: Aeson.FromJSON a => BL.ByteString -> Maybe a
+decodeJsonFirst s = Aeson.decode s <|> Yaml.decodeThrow (BL.toStrict s)
+
+encode :: Aeson.ToJSON a => Maybe AesonFormat -> Maybe FilePath -> a -> BL.ByteString
+encode (Just AesonYAML) _ = BL.fromStrict . Yaml.encode
+encode (Just AesonJSON) _ = Aeson.encode
+encode _ (Just fn) | ".yaml" `isSuffixOf` (toLower <$> fn) ||
+                     ".yml"  `isSuffixOf` (toLower <$> fn) = BL.fromStrict . Yaml.encode
+encode _ (Just fn) | ".json" `isSuffixOf` (toLower <$> fn) = Aeson.encode
+encode _ _ = Aeson.encode

--- a/src/diff.hs
+++ b/src/diff.hs
@@ -3,7 +3,8 @@
 module Main (main) where
 
 import           Control.Exception (bracket)
-import           Data.Aeson (Value, encode, decode)
+import           Codec (encode, decode, AesonFormat(..))
+import           Data.Aeson (Value)
 import           Data.Aeson.Diff (Config(Config), diff')
 import qualified Data.ByteString.Char8     as BS
 import qualified Data.ByteString.Lazy      as BSL
@@ -13,16 +14,20 @@ import           System.IO (Handle, IOMode(ReadMode, WriteMode), hClose, openFil
 
 type File = Maybe FilePath
 
+type Handle' = (Handle, Maybe AesonFormat, File)
+
 -- | Command-line options.
 data DiffOptions = DiffOptions
     { optionTst  :: Bool
     , optionOut  :: File
     , optionFrom :: File
     , optionTo   :: File
+    , optionYaml :: Bool
     }
 
 data Configuration = Configuration
-    { cfgTst  :: Bool
+    { cfgOptions :: DiffOptions
+    , cfgTst  :: Bool
     , cfgOut  :: Handle
     , cfgFrom :: Handle
     , cfgTo   :: Handle
@@ -48,6 +53,10 @@ optionParser = DiffOptions
     <*> argument fileP
         (  metavar "TO"
         )
+    <*> switch
+        (  long "yaml"
+        <> help "Use yaml decoding and encoding."
+        )
   where
     fileP = do
         s <- readerAsk
@@ -55,10 +64,10 @@ optionParser = DiffOptions
             "-" -> Nothing
             _ -> Just s
 
-jsonFile :: Handle -> IO Value
-jsonFile fp = do
+jsonFile :: Handle' -> IO Value
+jsonFile (fp, mformat, mfilepath) = do
     s <- BS.hGetContents fp
-    case decode (BSL.fromStrict s) of
+    case decode mformat mfilepath (BSL.fromStrict s) of
         Nothing -> error "Could not parse as JSON"
         Just v -> return v
 
@@ -74,9 +83,10 @@ run opt = bracket (load opt) close process
     openw (Just p) = openFile p WriteMode
 
     load :: DiffOptions -> IO Configuration
-    load DiffOptions{..} =
+    load options@DiffOptions{..} =
         Configuration
-            <$> pure  optionTst
+            <$> pure  options
+            <*> pure  optionTst
             <*> openw optionOut
             <*> openr optionFrom
             <*> openr optionTo
@@ -89,11 +99,12 @@ run opt = bracket (load opt) close process
 
 process :: Configuration -> IO ()
 process Configuration{..} = do
-    json_from <- jsonFile cfgFrom
-    json_to <- jsonFile cfgTo
+    let mformat = if optionYaml cfgOptions then Just AesonYAML else Nothing
+    json_from <- jsonFile (cfgFrom, mformat, optionFrom cfgOptions)
+    json_to <- jsonFile (cfgTo, mformat, optionTo cfgOptions)
     let c = Config cfgTst
     let p = diff' c json_from json_to
-    BS.hPutStrLn cfgOut $ BSL.toStrict (encode p)
+    BS.hPutStrLn cfgOut $ BSL.toStrict (encode mformat (optionOut cfgOptions) p)
 
 main :: IO ()
 main = execParser opts >>= run


### PR DESCRIPTION

This patch adds the option to the command line tools to encode and decode yaml format based on --yaml flag, filename suffixes (.yml or .yaml) or auto-detection.
