### PR TITLE
Autodocodec serialisers and array style pointers proposal

### DIFF
--- a/TOUCH
+++ b/TOUCH
@@ -1,0 +1,1 @@
+Touching a file just to make a diff. See PR description


### PR DESCRIPTION
Hi Janus

I was planning on using the library you currently maintain, `aeson-diff`, but make the following changes:

1. Add [autodocodec](https://hackage.haskell.org/package/autodocodec) instances to the `Patch` type, primarily so I can generate nice OpenAPI3 specs for this type AND
2. Have a version of `Patch` which doesn't serialise [`Pointer`](https://hackage.haskell.org/package/aeson-diff-1.1.0.13/docs/Data-Aeson-Pointer.html#t:Pointer) like `"/alice/1"` but instead as `["alice", 1]`. 

Regarding point 2, I just think the [RFC](https://datatracker.ietf.org/doc/html/rfc6902) is "wrong" here, and by "wrong" I mean I subjectively don't like it. 

I know there are typescript libraries to generate valid JSON patches, but I just think it's simplier if I can share the specification directly via types generated us [`autodocodec-openapi3`](https://hackage.haskell.org/package/autodocodec-openapi3), as we do we do with the rest of the API. 

That way there's strongly typed typescript types they can just fill in appropriately. And an array of values as a type for a path I think is just a more appropriate format than hacking together/pulling apart/escaping a string.

I plan to adjust the types like the following:

```
data PointerSerialisationFormat = PointerFormatStandard | PointerFormatArray
data Permissive = YesPermissive | NotPermissive

newtype Patch' (isPermissive :: YesPermissive) (serialisationFormat :: PointerSerialisationFormat) = ...

type Patch = Patch' NotPermissive PointerFormatStandard
```

The behaviour of `Patch` should not change. But there could be other type aliases of `Patch'` which have different behaviour.

The `serialisationFormat` permissive will determine whether the `ToJSON` and `ToSchema` (i.e. documentation) methods (which will be derived from the `autodocodec` `HasCodec` instance) will determine whether when we serialise `Pointer`s whether they are serialised as strings as per the RFC or as an array of values, with the path components being strings and any array components being integers.

The `permissive` parameter will determine whether the alternative format is accepted in the `FromJSON` method. i.e. if `isPermissive` is `YesPermissive` then string based paths will be accepted in the `FromJSON` method, even though the `ToJSON` method will output an array.

I'm raising this with you because I'm wondering whether you'd accept such a change to this library as a PR. I understand it's a significant change that includes adding some more dependencies, in particular `autodocodoc`. If you don't want to bloat the library in this way I can write my changes as a wrapper library that newtypes `Patch`. But if you're happy for these sort of changes I'm happy to fork the library can contribute the changes back to you. Entirely up to you. 

(I've created this as a silly PR just to get your attention and because I can't currently make issues on this repository)